### PR TITLE
[ chore ] : Okhttp client 추가

### DIFF
--- a/data/src/main/java/com/ddd/ansayo/data/datasource/auth/AuthLocalDataSource.kt
+++ b/data/src/main/java/com/ddd/ansayo/data/datasource/auth/AuthLocalDataSource.kt
@@ -1,0 +1,6 @@
+package com.ddd.ansayo.data.datasource.auth
+
+interface AuthLocalDataSource {
+
+    val authToken: String
+}

--- a/remote/src/main/java/com/ddd/ansayo/remote/di/NetworkModule.kt
+++ b/remote/src/main/java/com/ddd/ansayo/remote/di/NetworkModule.kt
@@ -1,0 +1,75 @@
+package com.ddd.ansayo.remote.di
+
+import com.ddd.ansayo.remote.interceptor.AuthHeaderInterceptor
+import com.ddd.ansayo.remote.interceptor.TokenAuthenticator
+import com.orhanobut.logger.Logger
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    private const val COMMON_TIME_OUT = 10L
+    private const val FILE_UPLOAD_TIME_OUT = 30L
+
+
+    @Provides
+    @Singleton
+    fun providesHttpLoggingInterceptor(): HttpLoggingInterceptor {
+        return HttpLoggingInterceptor { message -> Logger.d(message) }
+    }
+
+    @Provides
+    @Singleton
+    fun providesAuthClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+        authHeaderInterceptor: AuthHeaderInterceptor,
+        tokenAuthenticator: TokenAuthenticator
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .addInterceptor(authHeaderInterceptor)
+            .authenticator(tokenAuthenticator)
+            .connectTimeout(COMMON_TIME_OUT, TimeUnit.SECONDS)
+            .readTimeout(COMMON_TIME_OUT, TimeUnit.SECONDS)
+            .writeTimeout(COMMON_TIME_OUT, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun providesNoAuthClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .connectTimeout(COMMON_TIME_OUT, TimeUnit.SECONDS)
+            .readTimeout(COMMON_TIME_OUT, TimeUnit.SECONDS)
+            .writeTimeout(COMMON_TIME_OUT, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun providesFileUploadClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+        authHeaderInterceptor: AuthHeaderInterceptor,
+        tokenAuthenticator: TokenAuthenticator
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .addInterceptor(authHeaderInterceptor)
+            .authenticator(tokenAuthenticator)
+            .connectTimeout(FILE_UPLOAD_TIME_OUT, TimeUnit.SECONDS)
+            .readTimeout(FILE_UPLOAD_TIME_OUT, TimeUnit.SECONDS)
+            .writeTimeout(FILE_UPLOAD_TIME_OUT, TimeUnit.SECONDS)
+            .build()
+    }
+}

--- a/remote/src/main/java/com/ddd/ansayo/remote/interceptor/AuthHeaderInterceptor.kt
+++ b/remote/src/main/java/com/ddd/ansayo/remote/interceptor/AuthHeaderInterceptor.kt
@@ -1,0 +1,18 @@
+package com.ddd.ansayo.remote.interceptor
+
+import com.ddd.ansayo.data.datasource.auth.AuthLocalDataSource
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthHeaderInterceptor @Inject constructor(
+    private val authLocalDataSource: AuthLocalDataSource
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder().apply {
+            header("Authorization", authLocalDataSource.authToken)
+        }.build()
+        return chain.proceed(request)
+    }
+}

--- a/remote/src/main/java/com/ddd/ansayo/remote/interceptor/TokenAuthenticator.kt
+++ b/remote/src/main/java/com/ddd/ansayo/remote/interceptor/TokenAuthenticator.kt
@@ -1,0 +1,25 @@
+package com.ddd.ansayo.remote.interceptor
+
+import com.ddd.ansayo.data.datasource.auth.AuthLocalDataSource
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import java.net.HttpURLConnection
+import javax.inject.Inject
+
+class TokenAuthenticator @Inject constructor(
+    private val authLocalDataSource: AuthLocalDataSource
+) : Authenticator {
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        if (response.code == HttpURLConnection.HTTP_UNAUTHORIZED) {
+            // TODO("토큰 리프레시")
+
+            return response.request.newBuilder()
+                .header("Authorization", authLocalDataSource.authToken)
+                .build()
+        }
+        return null
+    }
+}


### PR DESCRIPTION
## 작업사항
Okhttp client를 추가했습니다.
일단은 3개의 Client만 추가했습니다
- Authorization이 반드시 헤더에 포함되는 client
  - 가장 많이 공통적으로 사용될걸로 생각했습니다.
- Authorization이 헤더에 포함되지 않는 client
  - 토큰이 반드시 필요없는 경우에는 리프레시 로직을 제외하기위해 분리했습니다.
- 파일 업로드를 위한 client
  - 이미지를 여러장 업로드할 경우 타임아웃을 더 길게 잡아야 할 것으로 판단되어서 분리했습니다.

## 참고사항
- 아직 토큰을 어떻게 저장할지에 대한 설계는 진행되지 않아서 인터페이스로만 나타냈습니다.
- 토큰 리프레시 로직도 아직 API 설계가 되어있지 않기때문에 TODO로 남아있습니다.