### PR TITLE
네트워크 응답 핸들링 라이브러리 추가

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ kotlin = "1.8.10"
 kotlinxCoroutines = "1.6.4"
 retrofit = "2.9.0"
 okhttp = "4.10.0"
+sandwich = "1.3.7"
 
 room = "2.5.0"
 
@@ -52,6 +53,7 @@ androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle
 activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "androidxActivity" }
 fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragment" }
 logger = { group = "com.orhanobut", name = "logger", version.ref = "logger" }
+sandwich = { group = "com.github.skydoves", name = "sandwich", version.ref = "sandwich" }
 
 # Test
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }

--- a/remote/build.gradle.kts
+++ b/remote/build.gradle.kts
@@ -18,4 +18,5 @@ dependencies {
     implementation(libs.bundles.okhttp)
     implementation(libs.bundles.retrofit)
     implementation(libs.logger)
+    implementation(libs.sandwich)
 }


### PR DESCRIPTION
## 지라티켓
<!-- 지라 티켓명 및 링크를 넣어주세요. -->
[DDD-56](https://dlawjddo9701.atlassian.net/browse/DDD-56)

## 작업사항
<!-- 작업 사항 및 변경 사항을 적어주세요. -->
네트워크 응답 핸들링 라이브러리를 추가했습니다.

## 참고사항
<!-- 이 외의 참고할 만한 사항을 적어주세요. -->
[해당 글](https://pluu.github.io/blog/android/2023/04/29/custom-calladapter-factory/)을 참고해서 Error를 핸들링하는 CallAdapter를 만들어보려했는데
비슷한 방식으로 잘 구현되어있는 라이브러리가 있어서 해당 [라이브러리](https://github.com/skydoves/sandwich)로 대체했습니다.

참고 : https://velog.io/@skydoves/retrofit-api-handling-sandwich

